### PR TITLE
Handle JSON backup errors

### DIFF
--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -19,3 +19,25 @@ def test_create_and_save_session():
         hist = dm.get_historical_data()
         assert len(hist) == 1
         assert hist[0]['total_punches'] == 5
+
+
+def test_json_backup_write_failure(tmp_path, capsys):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    dm = DataManager(data_dir=data_dir)
+    dm.create_new_session()
+    session_data = {
+        'date': '2023-01-01 00:00:00',
+        'duration': 5.0,
+        'total_punches': 2,
+        'punch_types': {'jab': 2},
+        'punches_per_minute': 24.0
+    }
+
+    os.chmod(data_dir, 0o500)
+    dm.save_session_data(session_data)
+    os.chmod(data_dir, 0o700)
+
+    output = capsys.readouterr().out
+    assert "Failed to write backup file" in output
+    assert len(list(data_dir.glob('session_*.json'))) == 0

--- a/utils/data_manager.py
+++ b/utils/data_manager.py
@@ -106,9 +106,13 @@ class DataManager:
         """Save a JSON backup of the session data"""
         backup_file = os.path.join(self.data_dir, f"session_{session_id}.json")
         
-        with open(backup_file, 'w') as f:
-            json.dump(session_data, f, indent=4)
-            
+        try:
+            with open(backup_file, 'w') as f:
+                json.dump(session_data, f, indent=4)
+        except IOError as e:
+            print(f"Failed to write backup file {backup_file}: {e}")
+            return
+
         print(f"Session backup saved to {backup_file}")
     
     def get_historical_data(self, limit=10):


### PR DESCRIPTION
## Summary
- handle JSON backup IO errors
- add test simulating write failure for backup

## Testing
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Handle JSON backup write errors gracefully by catching IOExceptions in the backup routine and add a test to verify the failure behavior.

Enhancements:
- Catch and log IOErrors when saving JSON backup files to prevent crashes

Tests:
- Add a test that simulates a write failure and verifies no backup file is created and an error message is printed