### PR TITLE
Update Python version references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Contributor Guidelines
+
+## Environment Setup
+
+Use **Python 3.11+**.
+
+## Testing
+
+Run `pytest`, `flake8`, and `black` before committing.
+Ensure your changes are tested, linted, and formatted prior to committing.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🥊 PunchTracker - AI Boxing Assistant 🥊
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
-![Python](https://img.shields.io/badge/python-v3.8+-blue.svg)
+![Python](https://img.shields.io/badge/python-v3.11+-blue.svg)
 ![TensorFlow](https://img.shields.io/badge/TensorFlow-v2.12+-orange.svg)
 ![OpenCV](https://img.shields.io/badge/OpenCV-v4.5+-green.svg)
 ![Status](https://img.shields.io/badge/status-active-success.svg)


### PR DESCRIPTION
## Summary
- add contributor guidelines in **AGENTS.md**
- bump README badge to Python 3.11+
- clarify testing instructions to include pytest, flake8, and black

## Testing
- `black --check .` *(fails: 8 files would be reformatted)*
- `flake8` *(fails: command not found)*
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_6845c112474483328ceaf6dac186daaa